### PR TITLE
WIP: 음식 룰렛 앱 구현 + UX 개선 (21개 User Story)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,22 +1,18 @@
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
     namespace = "com.example.mukmuk"
-    compileSdk {
-        version = release(36) {
-            minorApiLevel = 1
-        }
-    }
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.mukmuk"
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -33,13 +29,25 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+    buildFeatures {
+        compose = true
+    }
 }
 
 dependencies {
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.activity.compose)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.material3)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    debugImplementation(libs.androidx.ui.tooling)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,17 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Mukmuk" />
+        android:theme="@style/Theme.Mukmuk"
+        tools:targetApi="31">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Mukmuk">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>

--- a/app/src/main/java/com/example/mukmuk/MainActivity.kt
+++ b/app/src/main/java/com/example/mukmuk/MainActivity.kt
@@ -1,0 +1,19 @@
+package com.example.mukmuk
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import com.example.mukmuk.ui.theme.MukmukTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            MukmukTheme {
+                MukmukApp()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/MukmukApp.kt
+++ b/app/src/main/java/com/example/mukmuk/MukmukApp.kt
@@ -1,0 +1,63 @@
+package com.example.mukmuk
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.mukmuk.ui.RouletteViewModel
+import com.example.mukmuk.ui.components.BottomNavBar
+import com.example.mukmuk.ui.screens.HistoryScreen
+import com.example.mukmuk.ui.screens.RestaurantsScreen
+import com.example.mukmuk.ui.screens.RouletteScreen
+import com.example.mukmuk.ui.screens.SettingsScreen
+
+@Composable
+fun MukmukApp() {
+    val viewModel: RouletteViewModel = viewModel()
+    var currentRoute by rememberSaveable { mutableStateOf("roulette") }
+
+    Scaffold(
+        bottomBar = {
+            BottomNavBar(
+                currentRoute = currentRoute,
+                onNavigate = { currentRoute = it }
+            )
+        },
+        containerColor = androidx.compose.ui.graphics.Color.Transparent
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            AnimatedContent(
+                targetState = currentRoute,
+                transitionSpec = {
+                    fadeIn(animationSpec = tween(250)) togetherWith
+                        fadeOut(animationSpec = tween(250))
+                },
+                label = "screen_transition"
+            ) { route ->
+                when (route) {
+                    "roulette" -> RouletteScreen(viewModel = viewModel)
+                    "restaurants" -> RestaurantsScreen()
+                    "history" -> HistoryScreen()
+                    "settings" -> SettingsScreen()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/data/model/Category.kt
+++ b/app/src/main/java/com/example/mukmuk/data/model/Category.kt
@@ -1,0 +1,10 @@
+package com.example.mukmuk.data.model
+
+enum class Category(val displayName: String) {
+    KOREAN("한식"),
+    JAPANESE("일식"),
+    CHINESE("중식"),
+    WESTERN("양식"),
+    SNACK("분식"),
+    SOUTHEAST_ASIAN("동남아");
+}

--- a/app/src/main/java/com/example/mukmuk/data/model/HistoryEntry.kt
+++ b/app/src/main/java/com/example/mukmuk/data/model/HistoryEntry.kt
@@ -1,0 +1,6 @@
+package com.example.mukmuk.data.model
+
+data class HistoryEntry(
+    val menu: Menu,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/example/mukmuk/data/model/Menu.kt
+++ b/app/src/main/java/com/example/mukmuk/data/model/Menu.kt
@@ -1,0 +1,10 @@
+package com.example.mukmuk.data.model
+
+import androidx.compose.ui.graphics.Color
+
+data class Menu(
+    val name: String,
+    val emoji: String,
+    val category: Category,
+    val color: Color
+)

--- a/app/src/main/java/com/example/mukmuk/data/model/Restaurant.kt
+++ b/app/src/main/java/com/example/mukmuk/data/model/Restaurant.kt
@@ -1,0 +1,8 @@
+package com.example.mukmuk.data.model
+
+data class Restaurant(
+    val name: String,
+    val rating: Float,
+    val distance: String,
+    val reviews: Int
+)

--- a/app/src/main/java/com/example/mukmuk/data/repository/MenuRepository.kt
+++ b/app/src/main/java/com/example/mukmuk/data/repository/MenuRepository.kt
@@ -1,0 +1,27 @@
+package com.example.mukmuk.data.repository
+
+import androidx.compose.ui.graphics.Color
+import com.example.mukmuk.data.model.Category
+import com.example.mukmuk.data.model.Menu
+
+object MenuRepository {
+    val allMenus: List<Menu> = listOf(
+        Menu("김치찌개", "\uD83C\uDF72", Category.KOREAN, Color(0xFFE74C3C)),
+        Menu("돈까스", "\uD83E\uDD69", Category.JAPANESE, Color(0xFFF39C12)),
+        Menu("짜장면", "\uD83C\uDF5C", Category.CHINESE, Color(0xFF2C3E50)),
+        Menu("파스타", "\uD83C\uDF5D", Category.WESTERN, Color(0xFF27AE60)),
+        Menu("초밥", "\uD83C\uDF63", Category.JAPANESE, Color(0xFFE91E63)),
+        Menu("떡볶이", "\uD83C\uDF36\uFE0F", Category.SNACK, Color(0xFFFF5722)),
+        Menu("삼겹살", "\uD83E\uDD53", Category.KOREAN, Color(0xFFD35400)),
+        Menu("햄버거", "\uD83C\uDF54", Category.WESTERN, Color(0xFF8E44AD)),
+        Menu("쌀국수", "\uD83C\uDF5C", Category.SOUTHEAST_ASIAN, Color(0xFF1ABC9C)),
+        Menu("피자", "\uD83C\uDF55", Category.WESTERN, Color(0xFFC0392B)),
+        Menu("비빔밥", "\uD83C\uDF5A", Category.KOREAN, Color(0xFF2ECC71)),
+        Menu("라멘", "\uD83C\uDF5C", Category.JAPANESE, Color(0xFFF1C40F)),
+    )
+
+    fun getFilteredMenus(selectedCategories: Set<Category>): List<Menu> {
+        return if (selectedCategories.isEmpty()) allMenus
+        else allMenus.filter { it.category in selectedCategories }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/data/repository/RestaurantRepository.kt
+++ b/app/src/main/java/com/example/mukmuk/data/repository/RestaurantRepository.kt
@@ -1,0 +1,28 @@
+package com.example.mukmuk.data.repository
+
+import com.example.mukmuk.data.model.Restaurant
+
+object RestaurantRepository {
+    private val restaurantMap: Map<String, List<Restaurant>> = mapOf(
+        "김치찌개" to listOf(
+            Restaurant("시골집 김치찌개", 4.5f, "350m", 328),
+            Restaurant("어머니 손맛", 4.3f, "500m", 215),
+            Restaurant("종로 김치찌개", 4.7f, "800m", 512),
+        ),
+        "돈까스" to listOf(
+            Restaurant("카츠하우스", 4.6f, "200m", 445),
+            Restaurant("경양식 돈까스", 4.2f, "650m", 178),
+            Restaurant("사보텐", 4.4f, "1.2km", 367),
+        ),
+    )
+
+    private val defaultRestaurants = listOf(
+        Restaurant("맛있는 식당", 4.4f, "300m", 256),
+        Restaurant("인기 맛집", 4.6f, "550m", 412),
+        Restaurant("동네 단골집", 4.3f, "750m", 189),
+    )
+
+    fun getRestaurants(menuName: String): List<Restaurant> {
+        return restaurantMap[menuName] ?: defaultRestaurants
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/RouletteViewModel.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/RouletteViewModel.kt
@@ -1,0 +1,102 @@
+package com.example.mukmuk.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.example.mukmuk.data.model.Category
+import com.example.mukmuk.data.model.HistoryEntry
+import com.example.mukmuk.data.model.Menu
+import com.example.mukmuk.data.repository.MenuRepository
+import com.example.mukmuk.data.repository.RestaurantRepository
+
+class RouletteViewModel : ViewModel() {
+    var selectedCategories by mutableStateOf(emptySet<Category>())
+        private set
+
+    var isSpinning by mutableStateOf(false)
+        private set
+
+    var showResult by mutableStateOf(false)
+        private set
+
+    var selectedMenu by mutableStateOf<Menu?>(null)
+        private set
+
+    var rotation by mutableFloatStateOf(0f)
+        private set
+
+    private val _history = mutableListOf<HistoryEntry>()
+    val history: List<HistoryEntry> get() = _history.toList()
+
+    var showConfirmSnackbar by mutableStateOf(false)
+        private set
+
+    val categories = Category.entries.toList()
+
+    val filteredMenus: List<Menu>
+        get() = MenuRepository.getFilteredMenus(selectedCategories)
+
+    val restaurants
+        get() = selectedMenu?.let { RestaurantRepository.getRestaurants(it.name) } ?: emptyList()
+
+    fun toggleCategory(category: Category) {
+        selectedCategories = if (category in selectedCategories) {
+            selectedCategories - category
+        } else {
+            selectedCategories + category
+        }
+    }
+
+    fun updateSpinning(spinning: Boolean) {
+        isSpinning = spinning
+    }
+
+    fun updateRotation(newRotation: Float) {
+        rotation = newRotation
+    }
+
+    fun selectMenuAtIndex(index: Int) {
+        val menus = filteredMenus
+        if (index in menus.indices) {
+            selectedMenu = menus[index]
+        }
+    }
+
+    fun onSpinComplete(finalAngle: Float) {
+        val menus = filteredMenus
+        if (menus.isEmpty()) return
+        val normalized = ((finalAngle % 360f) + 360f) % 360f
+        val arc = 360f / menus.size
+        val index = ((360f - normalized + arc / 2f) % 360f / arc).toInt() % menus.size
+        selectedMenu = menus[index]
+        isSpinning = false
+    }
+
+    fun showResultScreen() {
+        showResult = true
+    }
+
+    fun resetToWheel() {
+        showResult = false
+        selectedMenu = null
+    }
+
+    fun confirmSelection() {
+        selectedMenu?.let { menu ->
+            _history.add(HistoryEntry(menu = menu))
+            showConfirmSnackbar = true
+            showResult = false
+            selectedMenu = null
+        }
+    }
+
+    fun dismissSnackbar() {
+        showConfirmSnackbar = false
+    }
+
+    fun clearAllCategories() {
+        selectedCategories = emptySet()
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/components/BottomNavBar.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/components/BottomNavBar.kt
@@ -1,0 +1,103 @@
+package com.example.mukmuk.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.ui.theme.DarkBackground
+import com.example.mukmuk.ui.theme.GoldAccent
+
+data class NavItem(
+    val icon: String,
+    val label: String,
+    val route: String
+)
+
+val navItems = listOf(
+    NavItem("\uD83C\uDFAF", "\uB8F0\uB81B", "roulette"),
+    NavItem("\uD83D\uDCCD", "\uB9DB\uC9D1", "restaurants"),
+    NavItem("\uD83D\uDCCB", "\uAE30\uB85D", "history"),
+    NavItem("\u2699\uFE0F", "\uC124\uC815", "settings"),
+)
+
+@Composable
+fun BottomNavBar(
+    currentRoute: String,
+    onNavigate: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(Color.Transparent, DarkBackground),
+                    startY = 0f,
+                    endY = 40f
+                )
+            )
+            .padding(horizontal = 24.dp, vertical = 12.dp)
+            .padding(bottom = 8.dp),
+        horizontalArrangement = Arrangement.SpaceAround
+    ) {
+        navItems.forEach { item ->
+            val isActive = item.route == currentRoute
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .defaultMinSize(minWidth = 56.dp, minHeight = 48.dp)
+                    .semantics {
+                        contentDescription = "${item.label} \uD0ED"
+                        role = Role.Tab
+                    }
+                    .clickable { onNavigate(item.route) }
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    text = item.icon,
+                    fontSize = 22.sp,
+                    modifier = Modifier.alpha(if (isActive) 1f else 0.4f)
+                )
+                Text(
+                    text = item.label,
+                    fontSize = 10.sp,
+                    fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal,
+                    color = if (isActive) GoldAccent else Color.White.copy(alpha = 0.4f),
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+                // Active indicator
+                if (isActive) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Box(
+                        modifier = Modifier
+                            .size(4.dp)
+                            .background(GoldAccent, CircleShape)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/components/CategoryChips.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/components/CategoryChips.kt
@@ -1,0 +1,88 @@
+package com.example.mukmuk.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.data.model.Category
+import com.example.mukmuk.ui.theme.CardBackground
+import com.example.mukmuk.ui.theme.ChipBorder
+import com.example.mukmuk.ui.theme.GoldAccent
+import com.example.mukmuk.ui.theme.TextSecondary
+
+@Composable
+fun CategoryChips(
+    categories: List<Category>,
+    selectedCategories: Set<Category>,
+    onToggle: (Category) -> Unit,
+    onClearAll: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        // "전체" chip - active when no categories are selected
+        FilterChip(
+            selected = selectedCategories.isEmpty(),
+            onClick = { onClearAll() },
+            label = {
+                Text(
+                    text = "\uC804\uCCB4",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            },
+            shape = RoundedCornerShape(20.dp),
+            border = BorderStroke(
+                1.5.dp,
+                if (selectedCategories.isEmpty()) GoldAccent else ChipBorder
+            ),
+            colors = FilterChipDefaults.filterChipColors(
+                containerColor = CardBackground,
+                labelColor = TextSecondary,
+                selectedContainerColor = GoldAccent.copy(alpha = 0.15f),
+                selectedLabelColor = GoldAccent
+            )
+        )
+
+        categories.forEach { category ->
+            val isSelected = category in selectedCategories
+            FilterChip(
+                selected = isSelected,
+                onClick = { onToggle(category) },
+                label = {
+                    Text(
+                        text = category.displayName,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                },
+                shape = RoundedCornerShape(20.dp),
+                border = BorderStroke(
+                    1.5.dp,
+                    if (isSelected) GoldAccent else ChipBorder
+                ),
+                colors = FilterChipDefaults.filterChipColors(
+                    containerColor = CardBackground,
+                    labelColor = TextSecondary,
+                    selectedContainerColor = GoldAccent.copy(alpha = 0.15f),
+                    selectedLabelColor = GoldAccent
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/components/MenuGrid.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/components/MenuGrid.kt
@@ -1,0 +1,78 @@
+package com.example.mukmuk.ui.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.data.model.Menu
+import com.example.mukmuk.ui.theme.CardBackground
+import com.example.mukmuk.ui.theme.CardBorder
+import com.example.mukmuk.ui.theme.TextHint
+import com.example.mukmuk.ui.theme.TextSecondary
+
+@Composable
+fun MenuGrid(
+    menus: List<Menu>,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.padding(horizontal = 24.dp)) {
+        Text(
+            text = "\uD83D\uDCA1 TIP: \uCE74\uD14C\uACE0\uB9AC \uD544\uD130\uB85C \uC6D0\uD558\uB294 \uC74C\uC2DD\uB9CC \uACE8\uB77C\uBCF4\uC138\uC694",
+            color = TextHint,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(bottom = 10.dp)
+        )
+        val displayMenus = menus.take(8)
+        val rows = displayMenus.chunked(4)
+        rows.forEachIndexed { rowIndex, rowMenus ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                rowMenus.forEach { menu ->
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = CardBackground,
+                        modifier = Modifier
+                            .weight(1f)
+                            .border(1.dp, CardBorder, RoundedCornerShape(12.dp))
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.padding(vertical = 10.dp, horizontal = 4.dp)
+                        ) {
+                            Text(text = menu.emoji, fontSize = 22.sp)
+                            Text(
+                                text = menu.name,
+                                color = TextSecondary,
+                                fontSize = 10.sp,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.padding(top = 2.dp)
+                            )
+                        }
+                    }
+                }
+                // Fill remaining cells with spacers if row is not full
+                repeat(4 - rowMenus.size) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+            if (rowIndex < rows.lastIndex) {
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/components/ResultScreen.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/components/ResultScreen.kt
@@ -1,0 +1,242 @@
+package com.example.mukmuk.ui.components
+
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.data.model.Menu
+import com.example.mukmuk.data.model.Restaurant
+import com.example.mukmuk.ui.theme.CardBackground
+import com.example.mukmuk.ui.theme.CardBorder
+import com.example.mukmuk.ui.theme.DarkBackground
+import com.example.mukmuk.ui.theme.GoldAccent
+import com.example.mukmuk.ui.theme.TextHint
+
+@Composable
+fun ResultScreen(
+    menu: Menu,
+    restaurants: List<Restaurant>,
+    onRetry: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = true,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { it / 4 })
+    ) {
+        Column(modifier = modifier.padding(horizontal = 20.dp)) {
+            // Selected menu card
+            Surface(
+                shape = RoundedCornerShape(24.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription = "\uC120\uD0DD\uB41C \uBA54\uB274: ${menu.name}, ${menu.category.displayName}"
+                    }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(
+                            Brush.linearGradient(
+                                colors = listOf(
+                                    menu.color.copy(alpha = 0.8f),
+                                    menu.color.copy(alpha = 0.53f)
+                                )
+                            )
+                        )
+                        .padding(28.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(text = menu.emoji, fontSize = 56.sp)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = menu.name,
+                            fontSize = 32.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Surface(
+                            shape = RoundedCornerShape(20.dp),
+                            color = Color.White.copy(alpha = 0.2f)
+                        ) {
+                            Text(
+                                text = menu.category.displayName,
+                                color = Color.White,
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Medium,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // Nearby restaurants header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "\uD83D\uDCCD \uADFC\uCC98 \uB9DB\uC9D1",
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = "\uC11C\uC6B8 \uAC15\uB0A8\uAD6C \uAE30\uC900",
+                    color = TextHint,
+                    fontSize = 12.sp
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Restaurant list
+            restaurants.forEach { restaurant ->
+                RestaurantCard(restaurant = restaurant)
+                Spacer(modifier = Modifier.height(10.dp))
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Action buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                OutlinedButton(
+                    onClick = onRetry,
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(14.dp),
+                    border = BorderStroke(1.dp, CardBorder),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = Color.White,
+                        containerColor = CardBackground
+                    )
+                ) {
+                    Text(
+                        text = "\uD83D\uDD04 \uB2E4\uC2DC \uB3CC\uB9AC\uAE30",
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(vertical = 6.dp)
+                    )
+                }
+                Button(
+                    onClick = onConfirm,
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(14.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = GoldAccent,
+                        contentColor = DarkBackground
+                    )
+                ) {
+                    Text(
+                        text = "\u2705 \uC774\uAC78\uB85C \uACB0\uC815!",
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(vertical = 6.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+        }
+    }
+}
+
+@Composable
+private fun RestaurantCard(restaurant: Restaurant) {
+    val context = LocalContext.current
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = CardBackground,
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, CardBorder, RoundedCornerShape(16.dp))
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = restaurant.name,
+                    color = Color.White,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                StarRating(rating = restaurant.rating)
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = "\uB9AC\uBDF0 ${restaurant.reviews}\uAC1C",
+                    color = TextHint,
+                    fontSize = 11.sp
+                )
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = restaurant.distance,
+                    color = GoldAccent,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = GoldAccent.copy(alpha = 0.15f),
+                    modifier = Modifier.clickable {
+                        Toast.makeText(
+                            context,
+                            "\uC9C0\uB3C4 \uAE30\uB2A5 \uC900\uBE44 \uC911\uC785\uB2C8\uB2E4",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                ) {
+                    Text(
+                        text = "\uC9C0\uB3C4 \uBCF4\uAE30",
+                        color = GoldAccent,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 5.dp)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/components/RouletteWheel.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/components/RouletteWheel.kt
@@ -1,0 +1,168 @@
+package com.example.mukmuk.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.example.mukmuk.data.model.Menu
+import com.example.mukmuk.ui.theme.DarkBackground
+import com.example.mukmuk.ui.theme.GoldAccent
+
+@Composable
+fun RouletteWheel(
+    menus: List<Menu>,
+    rotation: Float,
+    isSpinning: Boolean,
+    onSpin: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.size(280.dp),
+        contentAlignment = Alignment.TopCenter
+    ) {
+        // Pointer triangle at top
+        Canvas(modifier = Modifier.size(24.dp, 28.dp)) {
+            val path = Path().apply {
+                moveTo(size.width / 2f, 0f)
+                lineTo(0f, size.height)
+                lineTo(size.width, size.height)
+                close()
+            }
+            drawPath(path, GoldAccent)
+        }
+
+        // Wheel
+        Canvas(
+            modifier = Modifier
+                .size(280.dp)
+                .semantics { contentDescription = "\uC74C\uC2DD \uB8F0\uB81B \uD718. \uC911\uC559 GO \uBC84\uD2BC\uC744 \uD0ED\uD558\uC5EC \uD68C\uC804" }
+                .pointerInput(isSpinning) {
+                    if (!isSpinning) {
+                        detectTapGestures { offset ->
+                            val center = Offset(size.width / 2f, size.height / 2f)
+                            val distance = kotlin.math.sqrt(
+                                ((offset.x - center.x) * (offset.x - center.x) +
+                                 (offset.y - center.y) * (offset.y - center.y)).toDouble()
+                            ).toFloat()
+                            // 32.dp center circle - use approximate 40dp (generous touch target)
+                            val centerRadius = 40.dp.toPx()
+                            if (distance <= centerRadius) {
+                                onSpin()
+                            }
+                        }
+                    }
+                }
+        ) {
+            if (menus.isEmpty()) return@Canvas
+            val canvasSize = size.minDimension
+            val center = Offset(size.width / 2f, size.height / 2f)
+            val radius = canvasSize / 2f - 10.dp.toPx()
+            val arcAngle = 360f / menus.size
+
+            rotate(rotation, pivot = center) {
+                menus.forEachIndexed { index, menu ->
+                    val startAngle = index * arcAngle - 90f
+                    // Draw slice
+                    drawArc(
+                        color = menu.color.copy(alpha = 0.87f),
+                        startAngle = startAngle,
+                        sweepAngle = arcAngle,
+                        useCenter = true,
+                        topLeft = Offset(center.x - radius, center.y - radius),
+                        size = Size(radius * 2, radius * 2)
+                    )
+                    // Draw slice border
+                    drawArc(
+                        color = Color.White.copy(alpha = 0.3f),
+                        startAngle = startAngle,
+                        sweepAngle = arcAngle,
+                        useCenter = true,
+                        topLeft = Offset(center.x - radius, center.y - radius),
+                        size = Size(radius * 2, radius * 2),
+                        style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2.dp.toPx())
+                    )
+                    // Draw text
+                    drawMenuText(
+                        menu = menu,
+                        center = center,
+                        radius = radius,
+                        startAngle = startAngle,
+                        arcAngle = arcAngle
+                    )
+                }
+            }
+
+            // Center circle
+            drawCircle(
+                color = DarkBackground,
+                radius = 32.dp.toPx(),
+                center = center
+            )
+            drawCircle(
+                color = GoldAccent,
+                radius = 32.dp.toPx(),
+                center = center,
+                style = androidx.compose.ui.graphics.drawscope.Stroke(width = 3.dp.toPx())
+            )
+            // "GO" text
+            drawContext.canvas.nativeCanvas.apply {
+                val paint = android.graphics.Paint().apply {
+                    color = android.graphics.Color.parseColor("#FFB800")
+                    textSize = 14.dp.toPx()
+                    textAlign = android.graphics.Paint.Align.CENTER
+                    isFakeBoldText = true
+                    isAntiAlias = true
+                }
+                drawText("GO", center.x, center.y + 5.dp.toPx(), paint)
+            }
+        }
+    }
+}
+
+private fun DrawScope.drawMenuText(
+    menu: Menu,
+    center: Offset,
+    radius: Float,
+    startAngle: Float,
+    arcAngle: Float
+) {
+    val midAngle = Math.toRadians((startAngle + arcAngle / 2f).toDouble())
+    val textRadius = radius * 0.55f
+    val textX = center.x + textRadius * kotlin.math.cos(midAngle).toFloat()
+    val textY = center.y + textRadius * kotlin.math.sin(midAngle).toFloat()
+
+    drawContext.canvas.nativeCanvas.apply {
+        // Emoji
+        val emojiPaint = android.graphics.Paint().apply {
+            textSize = 16.dp.toPx()
+            textAlign = android.graphics.Paint.Align.CENTER
+            isAntiAlias = true
+        }
+        drawText(menu.emoji, textX, textY - 2.dp.toPx(), emojiPaint)
+
+        // Name
+        val namePaint = android.graphics.Paint().apply {
+            color = android.graphics.Color.WHITE
+            textSize = 11.dp.toPx()
+            textAlign = android.graphics.Paint.Align.CENTER
+            isFakeBoldText = true
+            isAntiAlias = true
+            setShadowLayer(4f, 0f, 2f, android.graphics.Color.argb(128, 0, 0, 0))
+        }
+        drawText(menu.name, textX, textY + 14.dp.toPx(), namePaint)
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/components/StarRating.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/components/StarRating.kt
@@ -1,0 +1,42 @@
+package com.example.mukmuk.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.ui.theme.GoldAccent
+import com.example.mukmuk.ui.theme.TextTertiary
+
+@Composable
+fun StarRating(rating: Float, modifier: Modifier = Modifier) {
+    val full = rating.toInt()
+    val hasHalf = (rating % 1f) >= 0.5f
+    val empty = 5 - full - if (hasHalf) 1 else 0
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.semantics {
+            contentDescription = "\uBCC4\uC810 ${rating}\uC810, 5\uC810 \uB9CC\uC810"
+        }
+    ) {
+        Text(
+            text = "\u2605".repeat(full) + (if (hasHalf) "\u00BD" else "") + "\u2606".repeat(empty),
+            color = GoldAccent,
+            fontSize = 12.sp,
+            letterSpacing = 1.sp
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = rating.toString(),
+            color = TextTertiary,
+            fontSize = 12.sp
+        )
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/screens/PlaceholderScreens.kt
@@ -1,0 +1,53 @@
+package com.example.mukmuk.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.ui.theme.DarkBackground
+import com.example.mukmuk.ui.theme.DarkSurface
+import com.example.mukmuk.ui.theme.DarkSurfaceVariant
+import com.example.mukmuk.ui.theme.GoldAccent
+import com.example.mukmuk.ui.theme.TextTertiary
+
+@Composable
+fun RestaurantsScreen() {
+    PlaceholderContent(icon = "\uD83D\uDCCD", title = "\uB9DB\uC9D1", subtitle = "\uACE7 \uB9CC\uB098\uC694!")
+}
+
+@Composable
+fun HistoryScreen() {
+    PlaceholderContent(icon = "\uD83D\uDCCB", title = "\uAE30\uB85D", subtitle = "\uACE7 \uB9CC\uB098\uC694!")
+}
+
+@Composable
+fun SettingsScreen() {
+    PlaceholderContent(icon = "\u2699\uFE0F", title = "\uC124\uC815", subtitle = "\uACE7 \uB9CC\uB098\uC694!")
+}
+
+@Composable
+private fun PlaceholderContent(icon: String, title: String, subtitle: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(DarkBackground, DarkSurface, DarkSurfaceVariant)
+                )
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(text = icon, fontSize = 48.sp)
+            Text(text = title, color = GoldAccent, fontSize = 24.sp, fontWeight = FontWeight.Bold)
+            Text(text = subtitle, color = TextTertiary, fontSize = 14.sp)
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/screens/RouletteScreen.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/screens/RouletteScreen.kt
@@ -1,0 +1,220 @@
+package com.example.mukmuk.ui.screens
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.ui.RouletteViewModel
+import com.example.mukmuk.ui.components.CategoryChips
+import com.example.mukmuk.ui.components.MenuGrid
+import com.example.mukmuk.ui.components.ResultScreen
+import com.example.mukmuk.ui.components.RouletteWheel
+import com.example.mukmuk.ui.theme.DarkBackground
+import com.example.mukmuk.ui.theme.DarkSurface
+import com.example.mukmuk.ui.theme.DarkSurfaceVariant
+import com.example.mukmuk.ui.theme.GoldAccent
+import com.example.mukmuk.ui.theme.TextTertiary
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun RouletteScreen(
+    viewModel: RouletteViewModel,
+    modifier: Modifier = Modifier
+) {
+    val scope = rememberCoroutineScope()
+    val animatable = remember { Animatable(viewModel.rotation) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val hapticFeedback = LocalHapticFeedback.current
+
+    LaunchedEffect(viewModel.showConfirmSnackbar) {
+        if (viewModel.showConfirmSnackbar) {
+            snackbarHostState.showSnackbar("\uB9DB\uC788\uAC8C \uB4DC\uC138\uC694! \uD83C\uDF7D\uFE0F")
+            viewModel.dismissSnackbar()
+        }
+    }
+
+    val spinWheel = {
+        if (!viewModel.isSpinning && viewModel.filteredMenus.isNotEmpty()) {
+            viewModel.updateSpinning(true)
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+            scope.launch {
+                val totalRotation = 1440f + (Math.random() * 1440f).toFloat()
+                val target = viewModel.rotation + totalRotation
+                animatable.snapTo(viewModel.rotation)
+                animatable.animateTo(
+                    targetValue = target,
+                    animationSpec = tween(
+                        durationMillis = 4000,
+                        easing = CubicBezierEasing(0.0f, 0.0f, 0.2f, 1.0f)
+                    )
+                ) {
+                    viewModel.updateRotation(value)
+                }
+                viewModel.onSpinComplete(target)
+                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                delay(300)
+                viewModel.showResultScreen()
+            }
+        }
+        Unit
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.linearGradient(
+                        colors = listOf(DarkBackground, DarkSurface, DarkSurfaceVariant)
+                    )
+                )
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+        // Header
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "\uC624\uB298 \uBFD0 \uBA39\uC9C0? \uD83E\uDD14",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            color = GoldAccent,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = "\uACE0\uBBFC\uC740 \uADF8\uB9CC, \uB8F0\uB81B\uC5D0 \uB9E1\uACA8!",
+            color = TextTertiary,
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 4.dp)
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Category chips
+        CategoryChips(
+            categories = viewModel.categories,
+            selectedCategories = viewModel.selectedCategories,
+            onToggle = { viewModel.toggleCategory(it) },
+            onClearAll = { viewModel.clearAllCategories() }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (!viewModel.showResult) {
+            if (viewModel.filteredMenus.isEmpty()) {
+                // Empty state
+                Spacer(modifier = Modifier.height(40.dp))
+                Text(
+                    text = "\uD83D\uDE45",
+                    fontSize = 48.sp
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "\uC120\uD0DD\uD55C \uCE74\uD14C\uACE0\uB9AC\uC5D0 \uBA54\uB274\uAC00 \uC5C6\uC5B4\uC694",
+                    color = TextTertiary,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(
+                    onClick = { viewModel.clearAllCategories() },
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = GoldAccent,
+                        contentColor = DarkBackground
+                    )
+                ) {
+                    Text(
+                        text = "\uC804\uCCB4 \uBCF4\uAE30",
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Spacer(modifier = Modifier.height(80.dp))
+            } else {
+                // Roulette wheel
+                RouletteWheel(
+                    menus = viewModel.filteredMenus,
+                    rotation = viewModel.rotation,
+                    isSpinning = viewModel.isSpinning,
+                    onSpin = { spinWheel() }
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // Spin button
+                Button(
+                    onClick = { spinWheel() },
+                    enabled = !viewModel.isSpinning && viewModel.filteredMenus.isNotEmpty(),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = GoldAccent,
+                        contentColor = DarkBackground,
+                        disabledContainerColor = GoldAccent.copy(alpha = 0.3f),
+                        disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                    ),
+                    modifier = Modifier.padding(horizontal = 48.dp)
+                ) {
+                    Text(
+                        text = if (viewModel.isSpinning) "\uD83C\uDFB0 \uB3CC\uB9AC\uB294 \uC911..." else "\uD83C\uDFAF \uB3CC\uB824!",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(vertical = 6.dp, horizontal = 16.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Menu grid
+                MenuGrid(menus = viewModel.filteredMenus)
+
+                Spacer(modifier = Modifier.height(80.dp)) // space for bottom nav
+            }
+        } else {
+            // Result screen
+            viewModel.selectedMenu?.let { menu ->
+                ResultScreen(
+                    menu = menu,
+                    restaurants = viewModel.restaurants,
+                    onRetry = { viewModel.resetToWheel() },
+                    onConfirm = { viewModel.confirmSelection() }
+                )
+            }
+            Spacer(modifier = Modifier.height(80.dp))
+        }
+        }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 80.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/theme/Color.kt
@@ -1,0 +1,16 @@
+package com.example.mukmuk.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val DarkBackground = Color(0xFF0F0F23)
+val DarkSurface = Color(0xFF1A1A2E)
+val DarkSurfaceVariant = Color(0xFF16213E)
+val GoldAccent = Color(0xFFFFB800)
+val GoldAccentDark = Color(0xFFFF8C00)
+val TextPrimary = Color.White
+val TextSecondary = Color.White.copy(alpha = 0.6f)
+val TextTertiary = Color.White.copy(alpha = 0.4f)
+val TextHint = Color.White.copy(alpha = 0.3f)
+val CardBackground = Color.White.copy(alpha = 0.05f)
+val CardBorder = Color.White.copy(alpha = 0.08f)
+val ChipBorder = Color.White.copy(alpha = 0.12f)

--- a/app/src/main/java/com/example/mukmuk/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/theme/Theme.kt
@@ -1,0 +1,26 @@
+package com.example.mukmuk.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+private val DarkColorScheme = darkColorScheme(
+    primary = GoldAccent,
+    secondary = GoldAccentDark,
+    background = DarkBackground,
+    surface = DarkSurface,
+    surfaceVariant = DarkSurfaceVariant,
+    onPrimary = DarkBackground,
+    onSecondary = DarkBackground,
+    onBackground = TextPrimary,
+    onSurface = TextPrimary,
+    onSurfaceVariant = TextSecondary,
+)
+
+@Composable
+fun MukmukTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = DarkColorScheme,
+        content = content
+    )
+}

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,16 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Theme.Mukmuk" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+    <!-- Base application theme for Compose app (no ActionBar needed). -->
+    <style name="Theme.Mukmuk" parent="android:Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,16 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Theme.Mukmuk" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+    <!-- Base application theme for Compose app (no ActionBar needed). -->
+    <style name="Theme.Mukmuk" parent="android:Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,17 @@
 [versions]
 agp = "9.0.0"
+kotlin = "2.0.21"
 coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 appcompat = "1.6.1"
 material = "1.10.0"
+composeBom = "2024.12.01"
+activityCompose = "1.9.3"
+lifecycleRuntimeKtx = "2.8.7"
+viewmodelCompose = "2.8.7"
+navigationCompose = "2.8.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -14,7 +20,18 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "viewmodelCompose" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
Core Features (US-001~009):
- Jetpack Compose + Material3, Dark theme (Gold #FFB800 accent)
- 룰렛 휠 Canvas (12개 메뉴, 컬러 슬라이스, 이모지)
- 스핀 애니메이션 (Animatable, 4s CubicBezierEasing)
- 결과 화면 (그라데이션 카드, 맛집 리스트, StarRating)
- 카테고리 필터 칩, 하단 4탭 네비게이션, 메뉴 그리드

UX Improvements (US-UX-001~012):
- "이걸로 결정!" 버튼 기능 구현 (히스토리 저장, Snackbar)
- BottomNavBar opacity 버그 수정 (Modifier.alpha, 활성 인디케이터)
- rememberSaveable로 화면 회전 시 상태 보존
- 터치 타겟 48dp 확대 (Material 가이드라인)
- TalkBack 접근성 (semantics 추가)
- 중첩 스크롤 해소 (LazyVerticalGrid → Column+Row)
- "전체" 필터 칩 추가
- 휠 중앙 GO만 클릭 가능 (pointerInput)
- 빈 상태 UI, "지도 보기" Toast, 햅틱 피드백
- AnimatedContent 화면 전환 애니메이션