### PR TITLE
feat: Room DB로 히스토리 영속 저장 구현 (#1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -45,6 +46,11 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
+
+    // Room
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/mukmuk/MukmukApp.kt
+++ b/app/src/main/java/com/example/mukmuk/MukmukApp.kt
@@ -44,7 +44,7 @@ fun MukmukApp() {
                     RestaurantsScreen()
                 }
                 composable(Screen.History.route) {
-                    HistoryScreen()
+                    HistoryScreen(viewModel = viewModel)
                 }
                 composable(Screen.Settings.route) {
                     SettingsScreen()

--- a/app/src/main/java/com/example/mukmuk/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/mukmuk/data/local/AppDatabase.kt
@@ -1,0 +1,29 @@
+package com.example.mukmuk.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.example.mukmuk.data.model.HistoryEntry
+
+@Database(entities = [HistoryEntry::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun historyDao(): HistoryDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        fun getInstance(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "mukmuk_database"
+                ).build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/data/local/HistoryDao.kt
+++ b/app/src/main/java/com/example/mukmuk/data/local/HistoryDao.kt
@@ -1,0 +1,19 @@
+package com.example.mukmuk.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.example.mukmuk.data.model.HistoryEntry
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface HistoryDao {
+    @Query("SELECT * FROM history ORDER BY timestamp DESC")
+    fun getAllHistory(): Flow<List<HistoryEntry>>
+
+    @Insert
+    suspend fun insert(entry: HistoryEntry)
+
+    @Query("DELETE FROM history")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/example/mukmuk/data/model/HistoryEntry.kt
+++ b/app/src/main/java/com/example/mukmuk/data/model/HistoryEntry.kt
@@ -1,6 +1,31 @@
 package com.example.mukmuk.data.model
 
+import androidx.compose.ui.graphics.Color
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "history")
 data class HistoryEntry(
-    val menu: Menu,
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val menuName: String,
+    val emoji: String,
+    val category: String,
+    val color: Long,
     val timestamp: Long = System.currentTimeMillis()
-)
+) {
+    fun toMenu(): Menu = Menu(
+        name = menuName,
+        emoji = emoji,
+        category = Category.valueOf(category),
+        color = Color(color.toULong())
+    )
+
+    companion object {
+        fun fromMenu(menu: Menu): HistoryEntry = HistoryEntry(
+            menuName = menu.name,
+            emoji = menu.emoji,
+            category = menu.category.name,
+            color = menu.color.value.toLong()
+        )
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/data/repository/HistoryRepository.kt
+++ b/app/src/main/java/com/example/mukmuk/data/repository/HistoryRepository.kt
@@ -1,0 +1,17 @@
+package com.example.mukmuk.data.repository
+
+import com.example.mukmuk.data.local.HistoryDao
+import com.example.mukmuk.data.model.HistoryEntry
+import kotlinx.coroutines.flow.Flow
+
+class HistoryRepository(private val historyDao: HistoryDao) {
+    val allHistory: Flow<List<HistoryEntry>> = historyDao.getAllHistory()
+
+    suspend fun insert(entry: HistoryEntry) {
+        historyDao.insert(entry)
+    }
+
+    suspend fun deleteAll() {
+        historyDao.deleteAll()
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/RouletteViewModel.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/RouletteViewModel.kt
@@ -1,17 +1,31 @@
 package com.example.mukmuk.ui
 
+import android.app.Application
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.mukmuk.data.local.AppDatabase
 import com.example.mukmuk.data.model.Category
 import com.example.mukmuk.data.model.HistoryEntry
 import com.example.mukmuk.data.model.Menu
+import com.example.mukmuk.data.repository.HistoryRepository
 import com.example.mukmuk.data.repository.MenuRepository
 import com.example.mukmuk.data.repository.RestaurantRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
-class RouletteViewModel : ViewModel() {
+class RouletteViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val historyRepository: HistoryRepository
+
+    init {
+        val dao = AppDatabase.getInstance(application).historyDao()
+        historyRepository = HistoryRepository(dao)
+    }
+
     var selectedCategories by mutableStateOf(emptySet<Category>())
         private set
 
@@ -27,8 +41,7 @@ class RouletteViewModel : ViewModel() {
     var rotation by mutableFloatStateOf(0f)
         private set
 
-    private val _history = mutableListOf<HistoryEntry>()
-    val history: List<HistoryEntry> get() = _history.toList()
+    val history: Flow<List<HistoryEntry>> = historyRepository.allHistory
 
     var showConfirmSnackbar by mutableStateOf(false)
         private set
@@ -85,7 +98,9 @@ class RouletteViewModel : ViewModel() {
 
     fun confirmSelection() {
         selectedMenu?.let { menu ->
-            _history.add(HistoryEntry(menu = menu))
+            viewModelScope.launch {
+                historyRepository.insert(HistoryEntry.fromMenu(menu))
+            }
             showConfirmSnackbar = true
             showResult = false
             selectedMenu = null
@@ -98,5 +113,11 @@ class RouletteViewModel : ViewModel() {
 
     fun clearAllCategories() {
         selectedCategories = emptySet()
+    }
+
+    fun clearHistory() {
+        viewModelScope.launch {
+            historyRepository.deleteAll()
+        }
     }
 }

--- a/app/src/main/java/com/example/mukmuk/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/screens/HistoryScreen.kt
@@ -1,0 +1,221 @@
+package com.example.mukmuk.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.data.model.HistoryEntry
+import com.example.mukmuk.ui.RouletteViewModel
+import com.example.mukmuk.ui.theme.DarkBackground
+import com.example.mukmuk.ui.theme.DarkSurface
+import com.example.mukmuk.ui.theme.DarkSurfaceVariant
+import com.example.mukmuk.ui.theme.GoldAccent
+import com.example.mukmuk.ui.theme.TextPrimary
+import com.example.mukmuk.ui.theme.TextSecondary
+import com.example.mukmuk.ui.theme.TextTertiary
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun HistoryScreen(viewModel: RouletteViewModel) {
+    val historyList by viewModel.history.collectAsState(initial = emptyList())
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(DarkBackground, DarkSurface, DarkSurfaceVariant)
+                )
+            )
+    ) {
+        if (historyList.isEmpty()) {
+            EmptyHistoryContent()
+        } else {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "선택 기록",
+                        color = GoldAccent,
+                        fontSize = 22.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    TextButton(onClick = { showDeleteDialog = true }) {
+                        Text(text = "전체 삭제", color = TextTertiary, fontSize = 13.sp)
+                    }
+                }
+
+                val grouped = groupByDate(historyList)
+
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    grouped.forEach { (dateLabel, entries) ->
+                        item {
+                            Text(
+                                text = dateLabel,
+                                color = TextSecondary,
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Medium,
+                                modifier = Modifier.padding(vertical = 8.dp, horizontal = 4.dp)
+                            )
+                        }
+                        items(entries, key = { it.id }) { entry ->
+                            HistoryCard(entry)
+                        }
+                    }
+                    item { Spacer(modifier = Modifier.height(16.dp)) }
+                }
+            }
+        }
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("기록 삭제") },
+            text = { Text("모든 선택 기록을 삭제하시겠습니까?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.clearHistory()
+                    showDeleteDialog = false
+                }) {
+                    Text("삭제", color = Color(0xFFFF6B6B))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("취소")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun EmptyHistoryContent() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(text = "\uD83D\uDCCB", fontSize = 48.sp)
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "아직 기록이 없어요",
+                color = GoldAccent,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "룰렛을 돌려 메뉴를 선택해보세요!",
+                color = TextTertiary,
+                fontSize = 14.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun HistoryCard(entry: HistoryEntry) {
+    val timeFormat = remember { SimpleDateFormat("HH:mm", Locale.getDefault()) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(DarkSurface.copy(alpha = 0.7f))
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(Color(entry.color.toULong()).copy(alpha = 0.2f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = entry.emoji, fontSize = 22.sp)
+        }
+        Spacer(modifier = Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = entry.menuName,
+                color = TextPrimary,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = entry.category,
+                color = TextTertiary,
+                fontSize = 12.sp
+            )
+        }
+        Text(
+            text = timeFormat.format(Date(entry.timestamp)),
+            color = TextTertiary,
+            fontSize = 12.sp
+        )
+    }
+}
+
+private fun groupByDate(entries: List<HistoryEntry>): List<Pair<String, List<HistoryEntry>>> {
+    val today = Calendar.getInstance()
+    val yesterday = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, -1) }
+    val dateFormat = SimpleDateFormat("M월 d일 (E)", Locale.KOREAN)
+
+    return entries.groupBy { entry ->
+        val cal = Calendar.getInstance().apply { timeInMillis = entry.timestamp }
+        when {
+            isSameDay(cal, today) -> "오늘"
+            isSameDay(cal, yesterday) -> "어제"
+            else -> dateFormat.format(Date(entry.timestamp))
+        }
+    }.toList()
+}
+
+private fun isSameDay(a: Calendar, b: Calendar): Boolean {
+    return a.get(Calendar.YEAR) == b.get(Calendar.YEAR) &&
+            a.get(Calendar.DAY_OF_YEAR) == b.get(Calendar.DAY_OF_YEAR)
+}

--- a/app/src/main/java/com/example/mukmuk/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/screens/PlaceholderScreens.kt
@@ -23,11 +23,6 @@ fun RestaurantsScreen() {
 }
 
 @Composable
-fun HistoryScreen() {
-    PlaceholderContent(icon = "\uD83D\uDCCB", title = "\uAE30\uB85D", subtitle = "\uACE7 \uB9CC\uB098\uC694!")
-}
-
-@Composable
 fun SettingsScreen() {
     PlaceholderContent(icon = "\u2699\uFE0F", title = "\uC124\uC815", subtitle = "\uACE7 \uB9CC\uB098\uC694!")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ activityCompose = "1.9.3"
 lifecycleRuntimeKtx = "2.8.7"
 viewmodelCompose = "2.8.7"
 navigationCompose = "2.8.5"
+room = "2.6.1"
+ksp = "2.0.21-1.0.28"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -30,8 +32,12 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "viewmodelCompose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
- Room + KSP 의존성 추가 (libs.versions.toml, build.gradle.kts)
- HistoryEntry @Entity로 변환 (flattened fields + toMenu/fromMenu 변환)
- HistoryDao, AppDatabase, HistoryRepository 생성
- RouletteViewModel을 AndroidViewModel로 변경하여 Room DB 연동
- HistoryScreen 실제 UI 구현 (날짜별 그룹핑, 빈 상태, 전체 삭제)
- PlaceholderScreens에서 HistoryScreen placeholder 제거

https://claude.ai/code/session_01KFC2MJTJG8JpZRDBDa1bA3