### PR TITLE
feat: 설정 화면 구현 - DataStore 기반 설정 영속화 (#4)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,6 +52,9 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
 
+    // DataStore
+    implementation(libs.androidx.datastore.preferences)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/mukmuk/MukmukApp.kt
+++ b/app/src/main/java/com/example/mukmuk/MukmukApp.kt
@@ -47,7 +47,7 @@ fun MukmukApp() {
                     HistoryScreen(viewModel = viewModel)
                 }
                 composable(Screen.Settings.route) {
-                    SettingsScreen()
+                    SettingsScreen(viewModel = viewModel)
                 }
             }
         }

--- a/app/src/main/java/com/example/mukmuk/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/example/mukmuk/data/repository/SettingsRepository.kt
@@ -1,0 +1,40 @@
+package com.example.mukmuk.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+class SettingsRepository(private val context: Context) {
+
+    private object Keys {
+        val HAPTIC_ENABLED = booleanPreferencesKey("haptic_enabled")
+        val DARK_THEME = booleanPreferencesKey("dark_theme")
+    }
+
+    val hapticEnabled: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        prefs[Keys.HAPTIC_ENABLED] ?: true
+    }
+
+    val darkTheme: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DARK_THEME] ?: true
+    }
+
+    suspend fun setHapticEnabled(enabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.HAPTIC_ENABLED] = enabled
+        }
+    }
+
+    suspend fun setDarkTheme(enabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.DARK_THEME] = enabled
+        }
+    }
+}

--- a/app/src/main/java/com/example/mukmuk/ui/RouletteViewModel.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/RouletteViewModel.kt
@@ -14,17 +14,27 @@ import com.example.mukmuk.data.model.Menu
 import com.example.mukmuk.data.repository.HistoryRepository
 import com.example.mukmuk.data.repository.MenuRepository
 import com.example.mukmuk.data.repository.RestaurantRepository
+import com.example.mukmuk.data.repository.SettingsRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class RouletteViewModel(application: Application) : AndroidViewModel(application) {
 
     private val historyRepository: HistoryRepository
+    val settingsRepository = SettingsRepository(application)
 
     init {
         val dao = AppDatabase.getInstance(application).historyDao()
         historyRepository = HistoryRepository(dao)
     }
+
+    val hapticEnabled = settingsRepository.hapticEnabled
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    val darkTheme = settingsRepository.darkTheme
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
     var selectedCategories by mutableStateOf(emptySet<Category>())
         private set
@@ -118,6 +128,18 @@ class RouletteViewModel(application: Application) : AndroidViewModel(application
     fun clearHistory() {
         viewModelScope.launch {
             historyRepository.deleteAll()
+        }
+    }
+
+    fun setHapticEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setHapticEnabled(enabled)
+        }
+    }
+
+    fun setDarkTheme(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setDarkTheme(enabled)
         }
     }
 }

--- a/app/src/main/java/com/example/mukmuk/ui/screens/PlaceholderScreens.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/screens/PlaceholderScreens.kt
@@ -23,11 +23,6 @@ fun RestaurantsScreen() {
 }
 
 @Composable
-fun SettingsScreen() {
-    PlaceholderContent(icon = "\u2699\uFE0F", title = "\uC124\uC815", subtitle = "\uACE7 \uB9CC\uB098\uC694!")
-}
-
-@Composable
 private fun PlaceholderContent(icon: String, title: String, subtitle: String) {
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/example/mukmuk/ui/screens/RouletteScreen.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/screens/RouletteScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -54,6 +56,7 @@ fun RouletteScreen(
     val animatable = remember { Animatable(viewModel.rotation) }
     val snackbarHostState = remember { SnackbarHostState() }
     val hapticFeedback = LocalHapticFeedback.current
+    val hapticEnabled by viewModel.hapticEnabled.collectAsState()
 
     LaunchedEffect(viewModel.showConfirmSnackbar) {
         if (viewModel.showConfirmSnackbar) {
@@ -65,7 +68,7 @@ fun RouletteScreen(
     val spinWheel = {
         if (!viewModel.isSpinning && viewModel.filteredMenus.isNotEmpty()) {
             viewModel.updateSpinning(true)
-            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+            if (hapticEnabled) hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
             scope.launch {
                 val totalRotation = 1440f + (Math.random() * 1440f).toFloat()
                 val target = viewModel.rotation + totalRotation
@@ -80,7 +83,7 @@ fun RouletteScreen(
                     viewModel.updateRotation(value)
                 }
                 viewModel.onSpinComplete(target)
-                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                if (hapticEnabled) hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                 delay(300)
                 viewModel.showResultScreen()
             }

--- a/app/src/main/java/com/example/mukmuk/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/mukmuk/ui/screens/SettingsScreen.kt
@@ -1,0 +1,293 @@
+package com.example.mukmuk.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mukmuk.ui.RouletteViewModel
+import com.example.mukmuk.ui.theme.DarkBackground
+import com.example.mukmuk.ui.theme.DarkSurface
+import com.example.mukmuk.ui.theme.DarkSurfaceVariant
+import com.example.mukmuk.ui.theme.GoldAccent
+import com.example.mukmuk.ui.theme.TextPrimary
+import com.example.mukmuk.ui.theme.TextSecondary
+import com.example.mukmuk.ui.theme.TextTertiary
+
+@Composable
+fun SettingsScreen(viewModel: RouletteViewModel) {
+    val hapticEnabled by viewModel.hapticEnabled.collectAsState()
+    val darkTheme by viewModel.darkTheme.collectAsState()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(DarkBackground, DarkSurface, DarkSurfaceVariant)
+                )
+            )
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+    ) {
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "설정",
+            color = GoldAccent,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // General section
+        SectionHeader(title = "일반")
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SettingsToggleItem(
+            icon = "📳",
+            title = "햅틱 피드백",
+            subtitle = "룰렛 조작 시 진동 피드백",
+            checked = hapticEnabled,
+            onCheckedChange = { viewModel.setHapticEnabled(it) }
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SettingsToggleItem(
+            icon = "🌙",
+            title = "다크 모드",
+            subtitle = "어두운 테마 사용 (라이트 모드 준비 중)",
+            checked = darkTheme,
+            onCheckedChange = { viewModel.setDarkTheme(it) }
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Data section
+        SectionHeader(title = "데이터")
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SettingsActionItem(
+            icon = "🗑️",
+            title = "기록 초기화",
+            subtitle = "모든 선택 기록을 삭제합니다",
+            actionColor = Color(0xFFFF6B6B),
+            onClick = { showDeleteDialog = true }
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Info section
+        SectionHeader(title = "정보")
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SettingsInfoItem(
+            icon = "📱",
+            title = "앱 버전",
+            value = "1.0"
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SettingsInfoItem(
+            icon = "🍽️",
+            title = "먹먹",
+            value = "오늘 뭐 먹지?"
+        )
+
+        Spacer(modifier = Modifier.height(100.dp))
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("기록 초기화") },
+            text = { Text("모든 선택 기록을 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.clearHistory()
+                    showDeleteDialog = false
+                }) {
+                    Text("삭제", color = Color(0xFFFF6B6B))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("취소")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        color = GoldAccent,
+        fontSize = 14.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(horizontal = 4.dp)
+    )
+}
+
+@Composable
+private fun SettingsToggleItem(
+    icon: String,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(DarkSurface.copy(alpha = 0.7f))
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier.size(36.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = icon, fontSize = 20.sp)
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = TextPrimary,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = subtitle,
+                color = TextTertiary,
+                fontSize = 12.sp
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = DarkBackground,
+                checkedTrackColor = GoldAccent,
+                uncheckedThumbColor = TextSecondary,
+                uncheckedTrackColor = DarkSurfaceVariant
+            )
+        )
+    }
+}
+
+@Composable
+private fun SettingsActionItem(
+    icon: String,
+    title: String,
+    subtitle: String,
+    actionColor: Color,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(DarkSurface.copy(alpha = 0.7f))
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier.size(36.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = icon, fontSize = 20.sp)
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = TextPrimary,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = subtitle,
+                color = TextTertiary,
+                fontSize = 12.sp
+            )
+        }
+        TextButton(onClick = onClick) {
+            Text(text = "초기화", color = actionColor, fontSize = 13.sp)
+        }
+    }
+}
+
+@Composable
+private fun SettingsInfoItem(
+    icon: String,
+    title: String,
+    value: String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(DarkSurface.copy(alpha = 0.7f))
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier.size(36.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = icon, fontSize = 20.sp)
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = title,
+                color = TextPrimary,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+        Text(
+            text = value,
+            color = TextTertiary,
+            fontSize = 14.sp
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ viewmodelCompose = "2.8.7"
 navigationCompose = "2.8.5"
 room = "2.6.1"
 ksp = "2.0.21-1.0.28"
+datastorePreferences = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -35,6 +36,7 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- DataStore Preferences 의존성 추가
- SettingsRepository 생성 (햅틱 피드백, 다크모드 설정 관리)
- SettingsScreen UI 구현 (햅틱 토글, 다크모드 토글, 기록 초기화, 앱 버전)
- RouletteViewModel에 설정 상태 및 변경 함수 추가
- RouletteScreen 햅틱 피드백을 설정에 따라 조건부 실행
- PlaceholderScreens에서 SettingsScreen placeholder 제거

https://claude.ai/code/session_01KFC2MJTJG8JpZRDBDa1bA3